### PR TITLE
Lisätty variant-attribuutti Icon-komponenttiin

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15032,9 +15032,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.15",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-      "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+      "version": "4.17.20",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+      "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
     },
     "lodash.debounce": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opetushallitus/virkailija-ui-components",
   "repository": "github:Opetushallitus/virkailija-ui-components",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "private": false,
   "license": "EUPL-1.1",
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
   },
   "dependencies": {
     "date-fns": "2.0.1",
-    "lodash": "4.17.15",
+    "lodash": "^4.17.20",
     "memoize-one": "5.1.1",
     "polished": "3.4.1",
     "react-day-picker": "7.3.2",

--- a/src/Icon/Icon.test.tsx
+++ b/src/Icon/Icon.test.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { render } from '../testUtils';
+import Icon from './index';
+
+it('Renders an icon', () => {
+  const { rootElement } = render(<Icon type="flag" />);
+  expect(rootElement).toMatchSnapshot();
+});
+
+it('Renders an outlined icon', () => {
+  const { rootElement } = render(<Icon type="flag" variant="outlined" />);
+  expect(rootElement).toMatchSnapshot();
+});

--- a/src/Icon/__snapshots__/Icon.test.tsx.snap
+++ b/src/Icon/__snapshots__/Icon.test.tsx.snap
@@ -1,0 +1,25 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Renders an icon 1`] = `
+.c0 {
+  font-size: 1.5rem;
+}
+
+<i
+  class="c0 material-icons "
+>
+  flag
+</i>
+`;
+
+exports[`Renders an outlined icon 1`] = `
+.c0 {
+  font-size: 1.5rem;
+}
+
+<i
+  class="c0 material-icons-outlined "
+>
+  flag
+</i>
+`;

--- a/src/Icon/index.tsx
+++ b/src/Icon/index.tsx
@@ -12,20 +12,30 @@ import {
 
 type SystemProps = ColorProps & SpaceProps & TypographyProps;
 
-const IconBase = styled.span<SystemProps>`
+const IconBase = styled.i<SystemProps>`
   font-size: 1.5rem;
   ${color};
   ${space};
   ${typography};
 `;
 
+type MaterialIconTheme =
+  | 'outlined'
+  | 'two-tone'
+  | 'round'
+  | 'sharp'
+  | undefined;
+
 export type IconProps = React.ComponentProps<typeof IconBase> & {
   type: string;
+  variant: MaterialIconTheme;
 };
 
 const Icon = React.forwardRef<HTMLSpanElement, IconProps>(
-  ({ type, className = '', ...props }, ref) => {
-    const iconClassName = `material-icons ${className}`;
+  ({ type, variant, className = '', ...props }, ref) => {
+    const iconClassName = `material-icons${
+      variant ? '-' + variant : ''
+    } ${className}`;
 
     return (
       <IconBase ref={ref} className={iconClassName} {...props}>


### PR DESCRIPTION
Aiemmassa toteutuksessa ei ollut mitään tapaa vaihtaa eri material-icons teemojen välillä. Joillakin ikoneilla pystyi käyttämään tyypissä "_outlined" tai "_outline" -päätettä, mutta tämä ei toiminut kaikille ikoneille.

https://stackoverflow.com/questions/50303454/how-to-use-the-new-material-design-icon-themes-outlined-rounded-two-tone-and